### PR TITLE
Make dependencies platform dependent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ readme = "README.md"
 description = "A Rust library to get the path of the currently executing process."
 keywords = ["current", "process", "executable"]
 
-[dependencies]
-libc = "0.2"
+[target.'cfg(windows)'.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"
+
+[target.'cfg(any(target_os="freebsd", target_os="dragonfly", target_os="netbsd", target_os="macos"))'.dependencies]
+libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,12 @@
 //! }
 //! ```
 
+#[cfg(windows)]
 extern crate kernel32;
-extern crate libc;
+#[cfg(windows)]
 extern crate winapi;
+#[cfg(any(target_os="freebsd", target_os="dragonfly", target_os="netbsd", target_os="macos"))]
+extern crate libc;
 
 
 use std::path::PathBuf;


### PR DESCRIPTION
So this is the result of our little discussion on issue #2, it doesn't add much, but it's cool to download only what you need!

I've tested it on my MacBook (and it only downloads libc), on windows (where it does not downloads libc), and on Linux with Arch, Ubuntu and Fedora, and it downloads nothing.

If you have any questions, let me know!