### PR TITLE
Fixed get_process_path() on macOS and added get_dylib_path()

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,50 @@
+name: Rust
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test_linux:
+    name: process_path_linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features
+
+  build_and_test_macos:
+    name: process_path_macos
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features
+          
+  build_and_test_windows:
+    name: process_path_windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["current", "process", "executable", "dylib", "dll"]
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["errhandlingapi", "libloaderapi", "minwindef", "winerror" ] }
 
-[target.'cfg(any(target_os="freebsd", target_os="dragonfly", target_os="netbsd", target_os="macos"))'.dependencies]
+[target.'cfg(any(target_os="linux", target_os="freebsd", target_os="dragonfly", target_os="netbsd", target_os="macos"))'.dependencies]
 libc = "0.2.81"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "process_path"
-version = "0.1.2"
-authors = ["Wesley Wiser <wwiser@gmail.com>"]
+version = "0.1.3"
+authors = ["Wesley Wiser <wwiser@gmail.com>", "Moritz Moeller <virtualritz@protonmail.com"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/wesleywiser/process_path"
 documentation = "https://docs.rs/process_path"
 readme = "README.md"
-description = "A Rust library to get the path of the currently executing process."
-keywords = ["current", "process", "executable"]
+edition = "2018"
+description = "Gets the path of the currently executing process or dynamic library."
+keywords = ["current", "process", "executable", "dylib", "dll"]
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
+winapi = { version = "0.3.9", features = ["errhandlingapi", "libloaderapi", "minwindef", "winerror" ] }
 
 [target.'cfg(any(target_os="freebsd", target_os="dragonfly", target_os="netbsd", target_os="macos"))'.dependencies]
-libc = "0.2"
+libc = "0.2.81"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # process_path
-A Rust library to get the path of the currently executing process.
-or the the current dynamic library.
+A Rust library to get the path of the currently executing process or
+the the current dynamic library.
 
 The latter is particualrly useful for ‘plug-in‘ type dynamic libraries
 that need to load resources stored relative to the location of the

--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ Copyright Wesley Wiser and `process_path` contributors.
 Licensed under either of
 * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
 at your option.

--- a/README.md
+++ b/README.md
@@ -1,52 +1,51 @@
 # process_path
-
 A Rust library to get the path of the currently executing process.
+or the the current dynamic library.
+
+The latter is particualrly useful for ‘plug-in‘ type dynamic libraries
+that need to load resources stored relative to the location of the
+library in the file system.
 
 ## Usage
-
 Add this to your `Cargo.toml`:
-
-    [dependencies]
-    process_path = "0.1"
-
+```toml
+[dependencies]
+process_path = "0.1.3"
+```
 and this to your crate root:
-
-    extern crate process_path;
-
+```rust
+use process_path;
+```
 ## Example
-
 This program prints its path to stdout:
+```rust
+use process_path::get_executable_path;
 
-    extern crate process_path;
-
-    use process_path::get_executable_path;
-
-    fn main() {
-        let path = get_executable_path();
-        match path {
-            None => println!("The process path could not be determined"),
-            Some(path) => println!("{:?}", path)
-        }
+fn main() {
+    let path = get_executable_path();
+    match path {
+        None => println!("The process path could not be determined"),
+        Some(path) => println!("{:?}", path)
     }
+}
+```
 
 ## Supported Platforms
 
-Platform     | Underlying API
------------- | ---------------------------------------------
-Linux        | `readlink(/proc/self/exe)`
-FreeBSD      | `sysctl(3)` or `readlink(/proc/curproc/file)`
-NetBSD       | `readlink(/proc/curproc/exe)`
-DragonflyBSD | `readlink(/proc/curproc/file)`
-macOS        | `_NSGetExecutablePath()`
-Windows      | `GetModuleFileName()`
+Platform     | Underlying API `get_executable_path()`        | `get_dylib_path()`
+------------ | --------------------------------------------- | ---------------------
+Linux        | `readlink(/proc/self/exe)`                    | `dladdr()`
+FreeBSD      | `sysctl(3)` or `readlink(/proc/curproc/file)` | `dladdr()`
+NetBSD       | `readlink(/proc/curproc/exe)`                 | `dladdr()`
+DragonflyBSD | `readlink(/proc/curproc/file)`                | `dladdr()`
+macOS        | `_NSGetExecutablePath()`                      | `dladdr()`
+Windows      | `GetModuleFileName()`                         | `GetModuleHandleEx()`
+
 
 ## License
-
-Copyright Wesley Wiser and process_path contributors.
+Copyright Wesley Wiser and `process_path` contributors.
 
 Licensed under either of
-
 * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-
 at your option.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A Rust library to get the path of the currently executing process or
 the the current dynamic library.
 
-The latter is particualrly useful for ‘plug-in‘ type dynamic libraries
+The latter is particularly useful for ‘plug-in‘ type dynamic libraries
 that need to load resources stored relative to the location of the
 library in the file system.
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -6,6 +6,6 @@ fn main() {
     let path = get_executable_path();
     match path {
         None => println!("The process path could not be determined"),
-        Some(path) => println!("{:?}", path)
+        Some(path) => println!("{:?}", path),
     }
 }

--- a/src/bsd.rs
+++ b/src/bsd.rs
@@ -1,33 +1,35 @@
+use libc::*;
 use std::fs::read_link;
 use std::path::PathBuf;
-use libc::*;
 use std::ptr;
 
 // http://stackoverflow.com/q/799679
 // http://stackoverflow.com/a/1024937
 
-#[cfg(target_os="netbsd")]
+#[cfg(target_os = "netbsd")]
 pub fn get_executable_path() -> Option<PathBuf> {
     read_link("/proc/curproc/exe").ok()
 }
 
-#[cfg(target_os="dragonfly")]
+#[cfg(target_os = "dragonfly")]
 pub fn get_executable_path() -> Option<PathBuf> {
     read_link("/proc/curproc/file").ok()
 }
 
-#[cfg(target_os="freebsd")]
+#[cfg(target_os = "freebsd")]
 pub fn get_executable_path() -> Option<PathBuf> {
     let mib = [CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1];
     let mut buf: Vec<u8> = Vec::with_capacity(1024);
     let mut cb = 1024 as size_t;
     let result = unsafe {
-        sysctl(mib.as_ptr(),
-               4,
-               buf.as_mut_ptr() as *mut c_void,
-               &mut cb as *mut size_t,
-               ptr::null(),
-               0)
+        sysctl(
+            mib.as_ptr(),
+            4,
+            buf.as_mut_ptr() as *mut c_void,
+            &mut cb as *mut size_t,
+            ptr::null(),
+            0,
+        )
     };
 
     // FreeBSD without procfs
@@ -47,5 +49,4 @@ pub fn get_executable_path() -> Option<PathBuf> {
         // FreeBSD with procfs
         read_link("/proc/curproc/file").ok()
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! # Executable & Dynamic Library Paths
-//! Utilitye functions to get the path of the currently executing
+//! Utility functions to get the path of the currently executing
 //! process or the the current dynamic library.
 //!
-//! The latter is particualrly useful for ‘plug-in‘ type dynamic
+//! The latter is particualrly useful for ‘plug-in’ type dynamic
 //! libraries that need to load resources stored relative to the
 //! location of the library in the file system.
 //! ## Example
@@ -13,6 +13,13 @@
 //!     Some(path) => println!("{:?}", path)
 //! }
 //! ```
+//! ## Supported Platforms
+//! * Linux
+//! * FreeBSD
+//! * NetBSD
+//! * DragonflyBSD
+//! * macOS
+//! * Windows
 use std::path::PathBuf;
 
 #[cfg(target_os = "linux")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ mod bsd;
 use bsd as os;
 
 #[cfg(any(
+    target_os = "linux",
     target_os = "freebsd",
     target_os = "dragonfly",
     target_os = "netbsd",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! Utility functions to get the path of the currently executing
 //! process or the the current dynamic library.
 //!
-//! The latter is particualrly useful for ‘plug-in’ type dynamic
+//! The latter is particularly useful for ‘plug-in’ type dynamic
 //! libraries that need to load resources stored relative to the
 //! location of the library in the file system.
 //! ## Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,11 @@
-//! A Rust library to get the path of the currently executing process.
-//! # Example
+//! # Executable & Dynamic Library Paths
+//! Utilitye functions to get the path of the currently executing
+//! process or the the current dynamic library.
+//!
+//! The latter is particualrly useful for ‘plug-in‘ type dynamic
+//! libraries that need to load resources stored relative to the
+//! location of the library in the file system.
+//! ## Example
 //! ```
 //! let path = process_path::get_executable_path();
 //! match path {
@@ -7,15 +13,6 @@
 //!     Some(path) => println!("{:?}", path)
 //! }
 //! ```
-
-#[cfg(windows)]
-extern crate kernel32;
-#[cfg(windows)]
-extern crate winapi;
-#[cfg(any(target_os="freebsd", target_os="dragonfly", target_os="netbsd", target_os="macos"))]
-extern crate libc;
-
-
 use std::path::PathBuf;
 
 #[cfg(target_os = "linux")]
@@ -28,19 +25,41 @@ mod macos;
 #[cfg(target_os = "macos")]
 use macos as os;
 
-#[cfg(any(target_os="freebsd", target_os="dragonfly", target_os="netbsd"))]
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd"))]
 mod bsd;
-#[cfg(any(target_os="freebsd", target_os="dragonfly", target_os="netbsd"))]
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd"))]
 use bsd as os;
 
-#[cfg(windows)]
-mod windows;
-#[cfg(windows)]
-use windows as os;
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "netbsd",
+    target_os = "macos"
+))]
+mod nix;
 
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+use windows as os;
 
 /// Gets the path of the currently running process. If the path cannot be determined,
 /// `None` is returned.
+#[inline]
 pub fn get_executable_path() -> Option<PathBuf> {
     os::get_executable_path()
+}
+
+/// Gets the path of the current dynamic library. If the path cannot be determined,
+/// `None` is returned.
+#[inline]
+pub fn get_dylib_path() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        os::get_dylib_path()
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        nix::get_dylib_path()
+    }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,6 +1,7 @@
 use std::fs::read_link;
 use std::path::PathBuf;
 
+#[inline]
 pub fn get_executable_path() -> Option<PathBuf> {
     read_link("/proc/self/exe").ok()
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,37 +1,32 @@
-use std::ffi::CString;
-use std::os::raw::c_char;
-use std::path::PathBuf;
-use libc::{c_int, uint32_t};
+use libc::c_int;
+use std::{ffi::CStr, os::raw::c_char, path::PathBuf};
 
-extern {
+extern "C" {
     #[link(name = "dyld")]
-    fn _NSGetExecutablePath(buf: *mut c_char, bufsize: *mut uint32_t) -> c_int;
+    fn _NSGetExecutablePath(buf: *mut c_char, bufsize: *mut u32) -> c_int;
 }
 
-
 pub fn get_executable_path() -> Option<PathBuf> {
-    fn get_executable_path(len: uint32_t) -> Option<CString> {
+    fn get_executable_path(len: u32) -> Option<PathBuf> {
         let mut buf = Vec::with_capacity(len as usize);
         let mut len = len;
         unsafe {
             let result = _NSGetExecutablePath(buf.as_mut_ptr(), &mut len);
             if result == 0 {
                 buf.set_len(len as usize);
-                //trim any excess null bytes from the vec
-                buf.retain(|c| *c != 0);
-                CString::new(buf.iter().map(|c| *c as u8).collect::<Vec<_>>()).ok()
+                Some(PathBuf::from(
+                    CStr::from_ptr(buf.as_ptr()).to_str().unwrap(),
+                ))
             } else if result == -1 {
-                //_NSGetExecutablePath sets len to the required size
+                // _NSGetExecutablePath sets len to the required size.
                 get_executable_path(len)
             } else {
-                //according to the docs, the possible return values should be >= -1
-                //so this shouldn't happen
+                // According to the docs, the possible return values
+                // should be >= -1 so this shouldn't happen.
                 None
             }
         }
     }
 
     get_executable_path(256)
-        .and_then(|p| p.into_string().ok())
-        .map(|p| p.into())
 }

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -1,4 +1,5 @@
 use std::{ffi::CStr, os::raw::c_void, path::PathBuf};
+use libc;
 
 #[inline]
 pub(crate) fn get_dylib_path() -> Option<PathBuf> {

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -1,0 +1,29 @@
+use std::{ffi::CStr, os::raw::c_void, path::PathBuf};
+
+#[inline]
+pub(crate) fn get_dylib_path() -> Option<PathBuf> {
+    let mut dl_info = libc::Dl_info {
+        dli_fname: core::ptr::null(),
+        dli_fbase: core::ptr::null_mut(),
+        dli_sname: core::ptr::null(),
+        dli_saddr: core::ptr::null_mut(),
+    };
+
+    if unsafe {
+        libc::dladdr(
+            get_dylib_path as *const c_void,
+            &mut dl_info as *mut libc::Dl_info,
+        ) != 0
+    } {
+        if core::ptr::null() == dl_info.dli_fname {
+            None
+        } else {
+            match unsafe { CStr::from_ptr(dl_info.dli_fname) }.to_str() {
+                Ok(path) => Some(PathBuf::from(path)),
+                Err(_) => None,
+            }
+        }
+    } else {
+        None
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,11 +2,17 @@ use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::ptr;
-use kernel32::{GetLastError, GetModuleFileNameW};
-use winapi::minwindef::DWORD;
-use winapi::winerror::ERROR_INSUFFICIENT_BUFFER;
+use winapi::shared::minwindef::DWORD;
+use winapi::um::{
+    errhandlingapi::GetLastError,
+    libloaderapi::{
+       GetModuleFileNameW, GetModuleHandleExW, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+        GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+    }
+};
+use winapi::shared::winerror::ERROR_INSUFFICIENT_BUFFER;
 
-pub fn get_executable_path() -> Option<PathBuf> {
+pub(crate) fn get_executable_path() -> Option<PathBuf> {
     fn get_executable_path(len: usize) -> Option<PathBuf> {
         let mut buf = Vec::with_capacity(len);
         unsafe {
@@ -14,12 +20,12 @@ pub fn get_executable_path() -> Option<PathBuf> {
             if ret == 0 {
                 None
             } else if ret < len {
-                //success, we need to trim trailing null bytes from the vec
+                // Success, we need to trim trailing null bytes from the vec.
                 buf.set_len(ret);
                 let s = OsString::from_wide(&buf);
                 Some(s.into())
             } else {
-                //The buffer might not be big enough so we need to check errno
+                // The buffer might not be big enough so we need to check errno.
                 let errno = GetLastError();
                 if errno == ERROR_INSUFFICIENT_BUFFER {
                     get_executable_path(len * 2)
@@ -31,4 +37,42 @@ pub fn get_executable_path() -> Option<PathBuf> {
     }
 
     get_executable_path(256)
+}
+
+pub(crate) fn get_dylib_path() -> Option<PathBuf> {
+    fn get_dylib_path(len: usize) -> Option<PathBuf> {
+        let mut buf = Vec::with_capacity(len);
+        unsafe {
+            let mut handle_module = core::ptr::null_mut();
+            if GetModuleHandleExW(
+                GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                    | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                get_dylib_path as *const _,
+                &mut handle_module,
+            ) != 0 {
+                None
+            } else {
+                let ret =
+                    GetModuleFileNameW(handle_module, buf.as_mut_ptr(), len as DWORD) as usize;
+                if ret == 0 {
+                    None
+                } else if ret < len {
+                    // Success, we need to trim trailing null bytes from the vec.
+                    buf.set_len(ret);
+                    let s = OsString::from_wide(&buf);
+                    Some(s.into())
+                } else {
+                    // The buffer might not be big enough so we need to check errno.
+                    let errno = GetLastError();
+                    if errno == ERROR_INSUFFICIENT_BUFFER {
+                        get_dylib_path(len * 2)
+                    } else {
+                        None
+                    }
+                }
+            }
+        }
+    }
+
+    get_dylib_path(256)
 }


### PR DESCRIPTION
`get_proces_path()` was broken on `macOS`. It looked like the code stripping the string of trailing `nul`s also stripped the terminator `nul` that `CString`/`CStr` looked for.  I.e. the returned string had trailing garbage or was sometimes even rejected (`None`) returned.

I added a new function, `get_dylib_path()` which returns the path of the currently running dylib/dll/so. When I was looking for for a project I'm working on I found your crate. But then I quickly realized that this is not the same as the path to the parent process executable. :)

As I'm on `macOS` I haven't tested the newly added function, `get_dylib_path()` on any other platform. 
The crate cross compiles fine for `Windows` and `Linux` but I have not ran the code on these platforms. I have also not tested any of the BSD variants at all (build or run).