### PR TITLE
Fix get_dylib_path() on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "process_path"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Moritz Moeller <virtualritz@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/wesleywiser/process_path"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ library in the file system.
 Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
-process_path = "0.1.3"
+process_path = "0.1.4"
 ```
 and this to your crate root:
 ```rust

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -49,7 +49,7 @@ pub(crate) fn get_dylib_path() -> Option<PathBuf> {
                     | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                 get_dylib_path as *const _,
                 &mut handle_module,
-            ) != 0 {
+            ) == 0 {
                 None
             } else {
                 let ret =

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::ptr;
-use winapi::shared::minwindef::DWORD;
+use winapi::shared::minwindef::{DWORD, MAX_PATH};
 use winapi::um::{
     errhandlingapi::GetLastError,
     libloaderapi::{
@@ -36,7 +36,7 @@ pub(crate) fn get_executable_path() -> Option<PathBuf> {
         }
     }
 
-    get_executable_path(256)
+    get_executable_path(MAX_PATH)
 }
 
 pub(crate) fn get_dylib_path() -> Option<PathBuf> {
@@ -74,5 +74,5 @@ pub(crate) fn get_dylib_path() -> Option<PathBuf> {
         }
     }
 
-    get_dylib_path(256)
+    get_dylib_path(MAX_PATH)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -3,14 +3,14 @@ use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::ptr;
 use winapi::shared::minwindef::{DWORD, MAX_PATH};
+use winapi::shared::winerror::ERROR_INSUFFICIENT_BUFFER;
 use winapi::um::{
     errhandlingapi::GetLastError,
     libloaderapi::{
-       GetModuleFileNameW, GetModuleHandleExW, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+        GetModuleFileNameW, GetModuleHandleExW, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
         GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-    }
+    },
 };
-use winapi::shared::winerror::ERROR_INSUFFICIENT_BUFFER;
 
 pub(crate) fn get_executable_path() -> Option<PathBuf> {
     fn get_executable_path(len: usize) -> Option<PathBuf> {
@@ -49,7 +49,8 @@ pub(crate) fn get_dylib_path() -> Option<PathBuf> {
                     | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                 get_dylib_path as *const _,
                 &mut handle_module,
-            ) == 0 {
+            ) == 0
+            {
                 None
             } else {
                 let ret =


### PR DESCRIPTION
The success and failure conditions for GetModuleHandleExW were flipped