### PR TITLE
Replace winapi with windows-rs; modernize pipelines; add tests and use latest best practices

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,50 +1,54 @@
-name: Rust
+name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_and_test_linux:
-    name: process_path_linux
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-features
+  ci:
+    name: CI (${{ matrix.os }}, ${{ matrix.rust }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: ['1.82', 'stable']
 
-  build_and_test_macos:
-    name: process_path_macos
-    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-features
-          
-  build_and_test_windows:
-    name: process_path_windows
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-features
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+        components: rustfmt, clippy
+
+    - name: Cache dependencies
+      uses: Swatinem/rust-cache@v2
+
+    - name: Check formatting
+      if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+      run: cargo fmt --all -- --check
+
+    - name: Clippy
+      if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+      run: cargo clippy --all-targets -- -D warnings
+
+    - name: Build
+      run: cargo build --release
+
+    - name: Run tests
+      run: cargo test --release
+
+    - name: Smoke test
+      run: cargo run --release --example example
+
+    - name: Build documentation
+      if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+      run: cargo doc --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "process_path"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Moritz Moeller <virtualritz@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/wesleywiser/process_path"
 documentation = "https://docs.rs/process_path"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.82.0" # unsafe extern "C" syntax and &raw mut require 1.82+
 description = "Gets the path of the currently executing process or dynamic library."
 keywords = ["current", "process", "executable", "dylib", "dll"]
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["errhandlingapi", "libloaderapi", "minwindef", "winerror" ] }
+windows-sys = { version = ">=0.59, <0.62", features = ["Win32_Foundation", "Win32_System_LibraryLoader"] }
 
 [target.'cfg(any(target_os="linux", target_os="freebsd", target_os="dragonfly", target_os="netbsd", target_os="macos", target_os="illumos", target_os="android"))'.dependencies]
-libc = "0.2.81"
+libc = "0.2.180"

--- a/README.md
+++ b/README.md
@@ -10,12 +10,9 @@ library in the file system.
 Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
-process_path = "0.1.4"
+process_path = "0.1.5"
 ```
-and this to your crate root:
-```rust
-use process_path;
-```
+
 ## Example
 This program prints its path to stdout:
 ```rust

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,5 +1,3 @@
-extern crate process_path;
-
 use process_path::get_executable_path;
 
 fn main() {

--- a/src/bsd.rs
+++ b/src/bsd.rs
@@ -26,7 +26,7 @@ pub fn get_executable_path() -> Option<PathBuf> {
             mib.as_ptr(),
             4,
             buf.as_mut_ptr() as *mut c_void,
-            &mut cb as *mut size_t,
+            &raw mut cb,
             ptr::null(),
             0,
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,3 +75,20 @@ pub fn get_dylib_path() -> Option<PathBuf> {
         nix::get_dylib_path()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn executable_path() {
+        let path = get_executable_path().expect("get_executable_path() returned None");
+        assert!(path.exists(), "executable path does not exist: {path:?}");
+    }
+
+    #[test]
+    fn dylib_path() {
+        let path = get_dylib_path().expect("get_dylib_path() returned None");
+        assert!(path.exists(), "dylib path does not exist: {path:?}");
+    }
+}

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,9 +1,8 @@
 use libc::c_int;
 use std::{ffi::CStr, os::raw::c_char, path::PathBuf};
 
-extern "C" {
-    #[link(name = "dyld")]
-    fn _NSGetExecutablePath(buf: *mut c_char, bufsize: *mut u32) -> c_int;
+unsafe extern "C" {
+    unsafe fn _NSGetExecutablePath(buf: *mut c_char, bufsize: *mut u32) -> c_int;
 }
 
 pub fn get_executable_path() -> Option<PathBuf> {

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -9,12 +9,7 @@ pub(crate) fn get_dylib_path() -> Option<PathBuf> {
         dli_saddr: core::ptr::null_mut(),
     };
 
-    if unsafe {
-        libc::dladdr(
-            get_dylib_path as *const c_void,
-            &mut dl_info as *mut libc::Dl_info,
-        ) != 0
-    } {
+    if unsafe { libc::dladdr(get_dylib_path as *const c_void, &raw mut dl_info) != 0 } {
         if dl_info.dli_fname.is_null() {
             None
         } else {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,21 +2,17 @@ use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::ptr;
-use winapi::shared::minwindef::{DWORD, MAX_PATH};
-use winapi::shared::winerror::ERROR_INSUFFICIENT_BUFFER;
-use winapi::um::{
-    errhandlingapi::GetLastError,
-    libloaderapi::{
-        GetModuleFileNameW, GetModuleHandleExW, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-        GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-    },
+use windows_sys::Win32::Foundation::{GetLastError, ERROR_INSUFFICIENT_BUFFER, MAX_PATH};
+use windows_sys::Win32::System::LibraryLoader::{
+    GetModuleFileNameW, GetModuleHandleExW, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+    GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
 };
 
 pub(crate) fn get_executable_path() -> Option<PathBuf> {
     fn get_executable_path(len: usize) -> Option<PathBuf> {
         let mut buf = Vec::with_capacity(len);
         unsafe {
-            let ret = GetModuleFileNameW(ptr::null_mut(), buf.as_mut_ptr(), len as DWORD) as usize;
+            let ret = GetModuleFileNameW(ptr::null_mut(), buf.as_mut_ptr(), len as u32) as usize;
             if ret == 0 {
                 None
             } else if ret < len {
@@ -36,7 +32,7 @@ pub(crate) fn get_executable_path() -> Option<PathBuf> {
         }
     }
 
-    get_executable_path(MAX_PATH)
+    get_executable_path(MAX_PATH as usize)
 }
 
 pub(crate) fn get_dylib_path() -> Option<PathBuf> {
@@ -48,13 +44,12 @@ pub(crate) fn get_dylib_path() -> Option<PathBuf> {
                 GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
                     | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                 get_dylib_path as *const _,
-                &mut handle_module,
+                &raw mut handle_module,
             ) == 0
             {
                 None
             } else {
-                let ret =
-                    GetModuleFileNameW(handle_module, buf.as_mut_ptr(), len as DWORD) as usize;
+                let ret = GetModuleFileNameW(handle_module, buf.as_mut_ptr(), len as u32) as usize;
                 if ret == 0 {
                     None
                 } else if ret < len {
@@ -75,5 +70,5 @@ pub(crate) fn get_dylib_path() -> Option<PathBuf> {
         }
     }
 
-    get_dylib_path(MAX_PATH)
+    get_dylib_path(MAX_PATH as usize)
 }


### PR DESCRIPTION
Most crates have moved on from winapi - this updates the dependency to windows-sys instead, and cleans up CI, tests and best practices